### PR TITLE
[codex] README에 프로젝트 기술 스택 정리

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,6 @@
-Codex-Tutorial
+- Java 21
+- Gradle
+- Spring Boot 4.0.4
+- Spring Web MVC
+- Lombok
+- JUnit 5

--- a/src/test/java/kr/higu/codextutorial/CodexTutorialApplicationTests.java
+++ b/src/test/java/kr/higu/codextutorial/CodexTutorialApplicationTests.java
@@ -19,7 +19,14 @@ class CodexTutorialApplicationTests {
     void readmeContainsOnlyExpectedText() throws IOException {
         String readme = Files.readString(Path.of("README.md"));
 
-        assertEquals("Codex-Tutorial", readme.trim());
+        assertEquals("""
+                - Java 21
+                - Gradle
+                - Spring Boot 4.0.4
+                - Spring Web MVC
+                - Lombok
+                - JUnit 5
+                """.trim(), readme.trim());
     }
 
 }


### PR DESCRIPTION
## Summary
- README를 프로젝트 기술 스택 목록만 남기도록 갱신했습니다
- `build.gradle` 기준으로 Java, Gradle, Spring Boot, Spring Web MVC, Lombok, JUnit 5를 명시했습니다
- README 내용을 검증하는 테스트 기대값도 새 요구사항에 맞게 수정했습니다

## Why
이슈 #4는 README에 현재 프로젝트 기술 스택을 한 줄씩 나열하도록 요구합니다. 기존 README는 제목 한 줄만 있어 완료 조건을 충족하지 못했습니다.

## Validation
- `./gradlew test`

Closes #4
